### PR TITLE
Fix failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 jdk: openjdk11
 env:
   global:
-    - PYENV_VERSION=3.7.1
+    - PYENV_VERSION=3.7.5
     - AWS_REGION="us-east-1"
     - AWS_DEFAULT_REGION=$AWS_REGION
 install:


### PR DESCRIPTION
Travis couldn't find pyenv:

    https://travis-ci.com/aws-cloudformation/aws-cloudformation-resource-providers-accessanalyzer/builds/141482611

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
